### PR TITLE
Bugfix: Command failed due to signal: Segmentation fault: 11

### DIFF
--- a/src/Settings.swift
+++ b/src/Settings.swift
@@ -9,18 +9,24 @@ import Foundation
 
 /// Animation settings.
 public struct animSettings {
-
+    init(delay: TimeInterval = 0, duration: TimeInterval = 1, ease: animEase = .easeOutQuint, completion: (animClosure)? = nil, isUserInteractionsEnabled: Bool = false) {
+        self.delay = delay
+        self.duration = duration
+        self.ease = ease
+        self.completion = completion
+        self.isUserInteractionsEnabled = isUserInteractionsEnabled
+    }
     /// Delay before animation starts.
-    public var delay: TimeInterval = 0
+    public var delay: TimeInterval
     /// Duration of animation.
-    public var duration: TimeInterval = 1
+    public var duration: TimeInterval
     /// Easing of animation.
-    public var ease: animEase = .easeOutQuint
+    public var ease: animEase
     /// Completion block which runs after animation.
     public var completion: (animClosure)?
     /// Preferred animator used for the animation.
     lazy public var preferredAnimator: AnimatorType = AnimatorType.default
     /// Enables user interactions on views while animating. Not available on macOS.
-    public var isUserInteractionsEnabled: Bool = false
+    public var isUserInteractionsEnabled: Bool
 
 }


### PR DESCRIPTION
Following error occurred when Carthage trying to compile in `release` mode with Xcode 9.3:

```
While silgen emitConstructor SIL function "@_T04anim0A8SettingsVACSd5delay_Sd8durationAA0A4EaseV4easeyycSg10completionSb25isUserInteractionsEnabledtcfC".
 for 'init(delay:duration:ease:completion:isUserInteractionsEnabled:)' at /Users/tengfoung/Developments/resi-mobile-ios/Carthage/Checkouts/anim/src/Settings.swift:11:15
```

This PR fix the compilation issue.
